### PR TITLE
Add terse alias for bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,15 @@ end # => Just(42)
 Nothing.bind do |x|
   rturn(x * x)
 end # => Nothing
+
+# We even have >= but you need to pass a Proc or a lambda.
+Just(42) >= -> (x) do
+  rturn(x - 21) >= -> (y) do
+    if x * x > 100 then rturn(y) else rturn(x) end
+  end
+end
 ```
+
 ## Contributing
 
 1. Fork it

--- a/lib/ribimaybe.rb
+++ b/lib/ribimaybe.rb
@@ -59,8 +59,12 @@ module Ribimaybe
       # No operation. Always returns Nothing.
       #
       Contract Proc => Nothing
-      def self.bind(&_)
+      def self.bind(fn = nil, &_)
         self
+      end
+
+      class << self
+        alias_method :>=, :bind
       end
     end
 

--- a/lib/ribimaybe.rb
+++ b/lib/ribimaybe.rb
@@ -165,9 +165,11 @@ module Ribimaybe
       # end # => Just(2)
       #
       Contract Proc => Or[Nothing, Just]
-      def bind(&fn)
-        fn.curry.(@value)
+      def bind(fn = nil, &block)
+        (fn || block).curry.(@value)
       end
+
+      alias_method :>=, :bind
     end
 
     # Converts nil to Nothing or lifts value into a Just. Accepts a optional

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module Ribimaybe
-  VERSION = "0.0.12"
+  VERSION = "0.0.13"
 end

--- a/spec/applicative_functor_spec.rb
+++ b/spec/applicative_functor_spec.rb
@@ -21,81 +21,83 @@ describe "Applicative Instance" do
     ->(x){ ->(y) { x } }.(SecureRandom.base64(1000))
   end
 
-  # pure id <*> v = v
-  describe "identity" do
-    context "when i have nothing" do
-      it do
-        expect(pure(&id).apply(Nothing)).to eq(Nothing)
+  [:apply, :>>].each do |m|
+    # pure id <*> v = v
+    describe "identity" do
+      context "when i have nothing" do
+        it do
+          expect(pure(&id).public_send(m, Nothing)).to eq(Nothing)
+        end
+      end
+
+      context "when i have just :x" do
+        it do
+          expect(pure(&id).public_send(m, pure(:x))).to eq(pure(:x))
+        end
       end
     end
 
-    context "when i have just :x" do
-      it do
-        expect(pure(&id).apply(pure(:x))).to eq(pure(:x))
+    # pure (.) <*> u <*> v <*> w = u <*> (v <*> w)
+    describe "composition" do
+      context "when i have nothing" do
+        it do
+          lhs = pure(&dot).public_send(m, pure(&f)).public_send(m, pure(&g)).public_send(m, Nothing)
+          rhs = pure(&f).public_send(m, pure(&g).public_send(m, Nothing))
+          expect(lhs).to eq(rhs)
+        end
       end
-    end
-  end
 
-  # pure (.) <*> u <*> v <*> w = u <*> (v <*> w)
-  describe "composition" do
-    context "when i have nothing" do
-      it do
-        lhs = pure(&dot).apply(pure(&f)).apply(pure(&g)).apply(Nothing)
-        rhs = pure(&f).apply(pure(&g).apply(Nothing))
-        expect(lhs).to eq(rhs)
-      end
-    end
-
-    context "when i have just :x" do
-      it do
-        lhs = pure(&dot).apply(pure(&f)).apply(pure(&g)).apply(pure(:x))
-        rhs = pure(&f).apply(pure(&g).apply(pure(:x)))
-        expect(lhs).to eq(rhs)
-      end
-    end
-  end
-
-  # pure f <*> pure x = pure (f x)
-  describe "homomorphism" do
-    context "when i have nothing" do
-      it do
-        expect(pure(&f).apply(Nothing)).to eq(Nothing)
+      context "when i have just :x" do
+        it do
+          lhs = pure(&dot).public_send(m, pure(&f)).public_send(m, pure(&g)).public_send(m, pure(:x))
+          rhs = pure(&f).public_send(m, pure(&g).public_send(m, pure(:x)))
+          expect(lhs).to eq(rhs)
+        end
       end
     end
 
-    context "when i have just :x" do
-      it do
-        expect(pure(&f).apply(pure(:x))).to eq(pure(f.(:x)))
+    # pure f <*> pure x = pure (f x)
+    describe "homomorphism" do
+      context "when i have nothing" do
+        it do
+          expect(pure(&f).public_send(m, Nothing)).to eq(Nothing)
+        end
       end
-    end
-  end
 
-  # u <*> pure y = pure ($ y) <*> u
-  describe "interchange" do
-    context "when i have nothing" do
-      it do
-        expect(pure(&f).apply(Nothing)).to eq(pure(&ap.(f)).apply(Nothing))
-      end
-    end
-
-    context "when i have just :x" do
-      it do
-        expect(pure(&f).apply(pure(:x))).to eq(pure(&ap.(f)).apply(pure(:x)))
-      end
-    end
-  end
-
-  # fmap f x = pure f <*> x
-  describe "map" do
-    context "when i have nothing" do
-      it do
-        expect(Nothing.map(&f)).to eq(pure(&f).apply(Nothing))
+      context "when i have just :x" do
+        it do
+          expect(pure(&f).public_send(m, pure(:x))).to eq(pure(f.(:x)))
+        end
       end
     end
 
-    context "when i have just :x" do
-      it do
-        expect(Just(:x).map(&f)).to eq(pure(&f).apply(Just(:x)))
+    # u <*> pure y = pure ($ y) <*> u
+    describe "interchange" do
+      context "when i have nothing" do
+        it do
+          expect(pure(&f).public_send(m, Nothing)).to eq(pure(&ap.(f)).public_send(m, Nothing))
+        end
+      end
+
+      context "when i have just :x" do
+        it do
+          expect(pure(&f).public_send(m, pure(:x))).to eq(pure(&ap.(f)).public_send(m, pure(:x)))
+        end
+      end
+    end
+
+    # fmap f x = pure f <*> x
+    describe "map" do
+      context "when i have nothing" do
+        it do
+          expect(Nothing.map(&f)).to eq(pure(&f).public_send(m, Nothing))
+        end
+      end
+
+      context "when i have just :x" do
+        it do
+          expect(Just(:x).map(&f)).to eq(pure(&f).public_send(m, Just(:x)))
+        end
       end
     end
   end

--- a/spec/monad_spec.rb
+++ b/spec/monad_spec.rb
@@ -17,51 +17,53 @@ describe "Monad Instance" do
     ->(x){ ->(y) { rturn(x) } }.(SecureRandom.base64(1000))
   end
 
-  # return a >>= f = f a
-  describe "left identity" do
-    context "when i have nothing" do
-      it do
-        expect(Nothing.bind(&lifted_id)).to eq(Nothing)
+  [:bind, :>=].each do |m|
+    # return a >>= f = f a
+    describe "left identity" do
+      context "when i have nothing" do
+        it do
+          expect(Nothing.public_send(m, &lifted_id)).to eq(Nothing)
+        end
+      end
+
+      context "when i have just :x" do
+        it do
+          expect(rturn(:x).public_send(m, &lifted_id)).to eq(lifted_id.(:x))
+        end
       end
     end
 
-    context "when i have just :x" do
-      it do
-        expect(rturn(:x).bind(&lifted_id)).to eq(lifted_id.(:x))
+    # m >>= return = m
+    describe "right identity" do
+      context "when i have nothing" do
+        it do
+          expect(Nothing.public_send(m, &lifted_id)).to eq(Nothing)
+        end
       end
-    end
-  end
 
-  # m >>= return = m
-  describe "right identity" do
-    context "when i have nothing" do
-      it do
-        expect(Nothing.bind(&lifted_id)).to eq(Nothing)
-      end
-    end
-
-    context "when i have just :x" do
-      it do
-        expect(Just(:x).bind(&lifted_id)).to eq(Just(:x))
-      end
-    end
-  end
-
-  # (m >>= f) >>= g = m >>= (\x -> f x >>= g)
-  describe "associativity" do
-    context "when i have nothing" do
-      it do
-        lhs = Nothing.bind(&f).bind(&g)
-        rhs = Nothing.bind { |x| f.(x).bind(&g) }
-        expect(lhs).to eq(rhs)
+      context "when i have just :x" do
+        it do
+          expect(Just(:x).public_send(m, &lifted_id)).to eq(Just(:x))
+        end
       end
     end
 
-    context "when i have just :x" do
-      it do
-        lhs = Just(:x).bind(&f).bind(&g)
-        rhs = Just(:x).bind { |x| f.(x).bind(&g) }
-        expect(lhs).to eq(rhs)
+    # (m >>= f) >>= g = m >>= (\x -> f x >>= g)
+    describe "associativity" do
+      context "when i have nothing" do
+        it do
+          lhs = Nothing.public_send(m, &f).public_send(m, &g)
+          rhs = Nothing.bind { |x| f.(x).public_send(m, &g) }
+          expect(lhs).to eq(rhs)
+        end
+      end
+
+      context "when i have just :x" do
+        it do
+          lhs = Just(:x).public_send(m, &f).public_send(m, &g)
+          rhs = Just(:x).bind { |x| f.(x).public_send(m, &g) }
+          expect(lhs).to eq(rhs)
+        end
       end
     end
   end


### PR DESCRIPTION
This PR adds an alias for bind. Note that the arguments for bind were changed to accept a `Proc` object or a block, but due to the way Ruby's syntax works `>=` must be passed a `Proc` object (lambda, proc, etc). 

Here's an example.

``` ruby
Just(42) >= -> (x) do
  rturn(x - 21) >= -> (y) do
    if x * x > 100 then rturn(y) else rturn(x) end
  end
end
```