### PR TITLE
Rename rturn to unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,20 +82,20 @@ include Ribimaybe::Maybe
 
 # Chain together computations and pretend you're a Haskeller.
 Just(42).bind do |x|
-  rturn(x - 21).bind do |y|
-    if x * x > 100 then rturn(x) else rturn(y) end
+  unit(x - 21).bind do |y|
+    if x * x > 100 then unit(x) else unit(y) end
   end
 end # => Just(42)
 
 # You guessed it! If have Nothing, you get Nothing.
 Nothing.bind do |x|
-  rturn(x * x)
+  unit(x * x)
 end # => Nothing
 
 # We even have >= but you need to pass a Proc or a lambda.
 Just(42) >= -> (x) do
-  rturn(x - 21) >= -> (y) do
-    if x * x > 100 then rturn(x) else rturn(y) end
+  unit(x - 21) >= -> (y) do
+    if x * x > 100 then unit(x) else unit(y) end
   end
 end # => Just(42)
 ```

--- a/lib/ribimaybe.rb
+++ b/lib/ribimaybe.rb
@@ -165,7 +165,7 @@ module Ribimaybe
       # ==== Examples
       #
       # Just(1).bind do |x|
-      #   rturn(x + x)
+      #   unit(x + x)
       # end # => Just(2)
       #
       Contract Proc => Or[Nothing, Just]
@@ -195,8 +195,8 @@ module Ribimaybe
       (value || fn) ? Just.new(value || fn.curry) : Nothing
     end
 
-    alias_method :Just,  :Maybe
-    alias_method :pure,  :Maybe
-    alias_method :rturn, :Maybe
+    alias_method :Just, :Maybe
+    alias_method :pure, :Maybe
+    alias_method :unit, :Maybe
   end
 end

--- a/spec/monad_spec.rb
+++ b/spec/monad_spec.rb
@@ -6,15 +6,15 @@ describe "Monad Instance" do
   end
 
   let(:lifted_id) do
-    ->(x) { id.(rturn(x)) }
+    ->(x) { id.(unit(x)) }
   end
 
   let(:f) do
-    ->(x){ ->(y) { rturn(x) } }.(SecureRandom.base64(1000))
+    ->(x){ ->(y) { unit(x) } }.(SecureRandom.base64(1000))
   end
 
   let(:g) do
-    ->(x){ ->(y) { rturn(x) } }.(SecureRandom.base64(1000))
+    ->(x){ ->(y) { unit(x) } }.(SecureRandom.base64(1000))
   end
 
   [:bind, :>=].each do |m|
@@ -28,7 +28,7 @@ describe "Monad Instance" do
 
       context "when i have just :x" do
         it do
-          expect(rturn(:x).public_send(m, &lifted_id)).to eq(lifted_id.(:x))
+          expect(unit(:x).public_send(m, &lifted_id)).to eq(lifted_id.(:x))
         end
       end
     end


### PR DESCRIPTION
This PR renames `rturn` to `unit`. The motivation for this is that `rturn` is more likely to be error-prone. 

I'll do an appropriate version bump and release later.